### PR TITLE
Add dark mode support

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -530,9 +530,27 @@ function initDarkMode() {
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const stored = localStorage.getItem('theme');
 
+    const sunIcon =
+        '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<circle cx="12" cy="12" r="5" />' +
+        '<line x1="12" y1="1" x2="12" y2="3" />' +
+        '<line x1="12" y1="21" x2="12" y2="23" />' +
+        '<line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />' +
+        '<line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />' +
+        '<line x1="1" y1="12" x2="3" y2="12" />' +
+        '<line x1="21" y1="12" x2="23" y2="12" />' +
+        '<line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />' +
+        '<line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />' +
+        '</svg>';
+
+    const moonIcon =
+        '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />' +
+        '</svg>';
+
     const apply = (theme) => {
         document.documentElement.setAttribute('data-theme', theme);
-        if (icon) icon.textContent = theme === 'dark' ? '☀️' : '🌙';
+        if (icon) icon.innerHTML = theme === 'dark' ? sunIcon : moonIcon;
     };
 
     apply(stored || (prefersDark ? 'dark' : 'light'));

--- a/assets/script.js
+++ b/assets/script.js
@@ -521,6 +521,29 @@ class ThemeManager {
     }
 }
 
+// Dark mode toggle functionality
+function initDarkMode() {
+    const toggleButton = document.getElementById('theme-toggle');
+    if (!toggleButton) return;
+
+    const icon = toggleButton.querySelector('.theme-icon');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const stored = localStorage.getItem('theme');
+
+    const apply = (theme) => {
+        document.documentElement.setAttribute('data-theme', theme);
+        if (icon) icon.textContent = theme === 'dark' ? '☀️' : '🌙';
+    };
+
+    apply(stored || (prefersDark ? 'dark' : 'light'));
+
+    toggleButton.addEventListener('click', () => {
+        const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        apply(current);
+        localStorage.setItem('theme', current);
+    });
+}
+
 // Initialize all managers when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
     // Initialize all components
@@ -531,7 +554,8 @@ document.addEventListener('DOMContentLoaded', () => {
     new AnimationManager();
     new PerformanceMonitor();
     new ThemeManager();
-    
+    initDarkMode();
+
     console.log('GSO website initialized successfully');
 });
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -156,23 +156,27 @@ a:hover {
     color: var(--text-primary);
 }
 
-.theme-toggle {
+#theme-toggle {
     background: none;
     border: 1px solid var(--border-color);
     border-radius: 6px;
-    padding: 0.5rem;
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
     cursor: pointer;
     transition: all 0.2s ease;
     color: var(--text-secondary);
 }
 
-.theme-toggle:hover {
+#theme-toggle:hover {
     background-color: var(--bg-secondary);
     color: var(--text-primary);
 }
 
-.theme-icon {
-    font-size: 1rem;
+.theme-icon svg {
     display: block;
 }
 
@@ -309,6 +313,12 @@ a:hover {
     max-width: 800px;
     display: block;
     margin: 0 auto;
+}
+
+[data-theme="dark"] .task-diagram {
+    background-color: #e0e0e0;
+    padding: 0.5rem;
+    border-radius: 6px;
 }
 
 .analysis-figure {
@@ -1053,6 +1063,7 @@ a:focus {
 /* Print styles */
 @media print {
     .navbar,
+    #theme-toggle,
     .theme-toggle,
     .copy-btn {
         display: none;

--- a/assets/style.css
+++ b/assets/style.css
@@ -29,6 +29,24 @@
     --error-color: #dc3545;
 }
 
+/* Dark theme overrides */
+[data-theme="dark"] {
+    --bg-primary: #121212;
+    --bg-secondary: #1e1e1e;
+    --bg-tertiary: #252525;
+    --text-primary: #f5f5f5;
+    --text-secondary: #cccccc;
+    --text-tertiary: #999999;
+    --accent-primary: #4dabf7;
+    --accent-secondary: #82c7ff;
+    --border-color: #333333;
+    --shadow-light: rgba(0, 0, 0, 0.5);
+    --shadow-medium: rgba(0, 0, 0, 0.6);
+    --shadow-heavy: rgba(0, 0, 0, 0.7);
+    --code-bg: #1e1e1e;
+    --code-border: #333333;
+}
+
 /* Typography */
 body {
     font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
@@ -96,7 +114,7 @@ a:hover {
     top: 0;
     left: 0;
     right: 0;
-    background-color: rgba(255, 255, 255, 0.95);
+    background-color: var(--bg-primary);
     border-bottom: 1px solid var(--border-color);
     backdrop-filter: blur(20px);
     z-index: 1000;

--- a/index.html
+++ b/index.html
@@ -22,6 +22,9 @@
                 <!-- <a href="#dataset">Dataset</a> -->
                 <a href="#analysis">Analysis</a>
                 <!-- <a href="#citation">Citation</a> -->
+                <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
+                    <span class="theme-icon">🌙</span>
+                </button>
             </div>
         </div>
     </nav>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
                 <a href="#analysis">Analysis</a>
                 <!-- <a href="#citation">Citation</a> -->
                 <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
-                    <span class="theme-icon">🌙</span>
+                    <span class="theme-icon"></span>
                 </button>
             </div>
         </div>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -24,6 +24,9 @@
                 <!-- <a href="index.html#dataset">Dataset</a> -->
                 <a href="index.html#analysis">Analysis</a>
                 <!-- <a href="index.html#citation">Citation</a> -->
+                <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
+                    <span class="theme-icon">🌙</span>
+                </button>
             </div>
         </div>
     </nav>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -25,7 +25,7 @@
                 <a href="index.html#analysis">Analysis</a>
                 <!-- <a href="index.html#citation">Citation</a> -->
                 <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
-                    <span class="theme-icon">🌙</span>
+                    <span class="theme-icon"></span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- design dark color palette via CSS variables
- show theme toggle button in navigation
- implement dark mode toggle script using `data-theme` attribute
- update navbar background to use theme variable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f4d3afc60832db5355f90e37a5ae3