### PR TITLE
feat: add Blog link to site header

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
                 <a href="#overview">Overview</a>
                 <a href="leaderboard.html">Leaderboard</a>
                 <a href="problems.html">Problems</a>
+                <a href="https://gso-blog.notion.site/" target="_blank" rel="noopener noreferrer">Blog</a>
                 <!-- <a href="#dataset">Dataset</a> -->
                 <!-- <a href="#analysis">Analysis</a> -->
                 <!-- <a href="#citation">Citation</a> -->

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -23,6 +23,7 @@
                 <a href="index.html#overview">Overview</a>
                 <a href="leaderboard.html" class="active">Leaderboard</a>
                 <a href="problems.html">Problems</a>
+                <a href="https://gso-blog.notion.site/" target="_blank" rel="noopener noreferrer">Blog</a>
                 <!-- <a href="index.html#dataset">Dataset</a> -->
                 <!-- <a href="index.html#analysis">Analysis</a> -->
                 <!-- <a href="index.html#citation">Citation</a> -->

--- a/problems.html
+++ b/problems.html
@@ -22,6 +22,7 @@
                 <a href="index.html#overview">Overview</a>
                 <a href="leaderboard.html">Leaderboard</a>
                 <a href="problems.html" class="active">Problems</a>
+                <a href="https://gso-blog.notion.site/" target="_blank" rel="noopener noreferrer">Blog</a>
                 <!-- <a href="index.html#analysis">Analysis</a> -->
                 <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
                     <span class="theme-icon"></span>


### PR DESCRIPTION
Add a "Blog" anchor linking to `https://gso-blog.notion.site/` (with `target="_blank"` and `rel="noopener noreferrer"`) to the navigation in `index.html`, `leaderboard.html`, and `problems.html`.