### PR TITLE
fix: simplify mobile nav to Leaderboard + theme toggle

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -953,22 +953,22 @@ a:hover {
 }
 
 @media (max-width: 480px) {
-    .nav-links a:not(.theme-toggle) {
+    .nav-hide-mobile {
         display: none;
     }
-    
+
     .hero-title {
         font-size: 1.75rem;
     }
-    
+
     .stats-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .tab-buttons {
         flex-wrap: wrap;
     }
-    
+
     .tab-button {
         flex: 1 1 50%;
         min-width: 150px;

--- a/index.html
+++ b/index.html
@@ -17,10 +17,9 @@
                 <h1>GSO</h1>
             </div>
             <div class="nav-links">
-                <a href="#overview">Overview</a>
                 <a href="leaderboard.html">Leaderboard</a>
-                <a href="problems.html">Problems</a>
-                <a href="https://gso-blog.notion.site/" target="_blank" rel="noopener noreferrer">Blog</a>
+                <a href="problems.html" class="nav-hide-mobile">Problems</a>
+                <a href="https://gso-blog.notion.site/" target="_blank" rel="noopener noreferrer" class="nav-hide-mobile">Blog</a>
                 <!-- <a href="#dataset">Dataset</a> -->
                 <!-- <a href="#analysis">Analysis</a> -->
                 <!-- <a href="#citation">Citation</a> -->

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -20,10 +20,9 @@
                 </a>
             </div>
             <div class="nav-links">
-                <a href="index.html#overview">Overview</a>
                 <a href="leaderboard.html" class="active">Leaderboard</a>
-                <a href="problems.html">Problems</a>
-                <a href="https://gso-blog.notion.site/" target="_blank" rel="noopener noreferrer">Blog</a>
+                <a href="problems.html" class="nav-hide-mobile">Problems</a>
+                <a href="https://gso-blog.notion.site/" target="_blank" rel="noopener noreferrer" class="nav-hide-mobile">Blog</a>
                 <!-- <a href="index.html#dataset">Dataset</a> -->
                 <!-- <a href="index.html#analysis">Analysis</a> -->
                 <!-- <a href="index.html#citation">Citation</a> -->

--- a/problems.html
+++ b/problems.html
@@ -19,10 +19,9 @@
                 </a>
             </div>
             <div class="nav-links">
-                <a href="index.html#overview">Overview</a>
                 <a href="leaderboard.html">Leaderboard</a>
-                <a href="problems.html" class="active">Problems</a>
-                <a href="https://gso-blog.notion.site/" target="_blank" rel="noopener noreferrer">Blog</a>
+                <a href="problems.html" class="nav-hide-mobile">Problems</a>
+                <a href="https://gso-blog.notion.site/" target="_blank" rel="noopener noreferrer" class="nav-hide-mobile">Blog</a>
                 <!-- <a href="index.html#analysis">Analysis</a> -->
                 <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
                     <span class="theme-icon"></span>


### PR DESCRIPTION
## Summary
- On mobile screens (≤480px), simplify the nav to show only **Leaderboard** and the **theme toggle**
- Remove the Overview link from nav entirely (on all screen sizes)
- Hide Problems and Blog links on mobile via `.nav-hide-mobile` class

## Test plan
- [x] Check desktop: nav shows Leaderboard, Problems, Blog, and theme toggle
- [x] Check mobile (≤480px): nav shows only Leaderboard and theme toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)