### PR TITLE
Revamp landing page with leaderboard preview

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -114,6 +114,55 @@ a:hover {
     max-width: 800px;
 }
 
+.section-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.section-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+}
+
+.stat-card {
+    background: var(--bg-primary);
+    border-radius: 10px;
+    padding: 1.5rem;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 12px 24px var(--shadow-light);
+}
+
+.stat-kicker {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-tertiary);
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+.stat-value {
+    font-size: 1.4rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    color: var(--text-primary);
+}
+
+.stat-detail {
+    margin-bottom: 0;
+}
+
 /* Navigation */
 .navbar {
     position: sticky;
@@ -345,6 +394,14 @@ a:hover {
 .leaderboard-container {
     margin-bottom: 2rem;
     position: relative;
+}
+
+.leaderboard-preview .leaderboard-table {
+    max-height: 360px;
+    overflow: auto;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--bg-primary);
 }
 
 .leaderboard-table-wrapper {

--- a/index.html
+++ b/index.html
@@ -55,6 +55,67 @@
                             <path d="M1 8a.5.5 0 0 1 .5-.5h10.793L9.146 4.354a.5.5 0 1 1 .708-.708l4.5 4.5a.5.5 0 0 1 0 .708l-4.5 4.5a.5.5 0 0 1-.708-.708L12.293 8.5H1.5A.5.5 0 0 1 1 8z"/>
                         </svg>
                     </a>
+                    <a href="#leaderboard" class="btn btn-secondary">
+                        <span>Leaderboard</span>
+                        <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M1 8a.5.5 0 0 1 .5-.5h10.793L9.146 4.354a.5.5 0 1 1 .708-.708l4.5 4.5a.5.5 0 0 1 0 .708l-4.5 4.5a.5.5 0 0 1-.708-.708L12.293 8.5H1.5A.5.5 0 0 1 1 8z"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <section id="at-a-glance" class="section section-alt">
+            <div class="container">
+                <div class="section-header">
+                    <div>
+                        <h2>At a Glance</h2>
+                        <p class="section-subtitle">A quick snapshot of the scale and scope of the GSO benchmark.</p>
+                    </div>
+                </div>
+                <div class="stats-grid">
+                    <div class="stat-card">
+                        <p class="stat-kicker">Optimization Tasks</p>
+                        <p class="stat-value">102 real-world tasks</p>
+                        <p class="stat-detail">Generated from repository histories and validated for diversity.</p>
+                    </div>
+                    <div class="stat-card">
+                        <p class="stat-kicker">Codebase Coverage</p>
+                        <p class="stat-value">10 codebases · 8 domains</p>
+                        <p class="stat-detail">Spanning data systems, ML tooling, graphics, and more.</p>
+                    </div>
+                    <div class="stat-card">
+                        <p class="stat-kicker">Language Mix</p>
+                        <p class="stat-value">5 languages</p>
+                        <p class="stat-detail">~60% of tasks require non-Python edits.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="leaderboard" class="section">
+            <div class="container">
+                <div class="section-header">
+                    <div>
+                        <h2>Leaderboard</h2>
+                        <p class="section-subtitle">Latest Opt@1 results, with filters and search. Scroll to explore the full table.</p>
+                    </div>
+                    <div class="section-actions">
+                        <a href="leaderboard.html" class="btn btn-secondary">View full leaderboard</a>
+                    </div>
+                </div>
+                <div class="leaderboard-container leaderboard-preview">
+                    <div id="leaderboard-filters" class="leaderboard-filters-bar"></div>
+                    <div class="leaderboard-loading" id="leaderboard-loading">
+                        <div class="spinner"></div>
+                        <span>Loading leaderboard...</span>
+                    </div>
+                    <div class="leaderboard-table" id="leaderboard-table" style="display: none;">
+                        <!-- Leaderboard will be populated by JavaScript -->
+                    </div>
+                </div>
+                <div class="leaderboard-footnotes">
+                    <p><strong>Opt@1:</strong> Fraction of tasks where a single attempt achieves ≥95% human speedup and passes correctness tests.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
### Motivation
- Make core benchmark information immediately visible on the landing page by surfacing a compact leaderboard and concise stats, reducing the need to navigate to a separate page.
- Preserve the existing visual language (fonts, colors, layout) while adding a short, scannable summary band for visitors.

### Description
- Add an `At a Glance` stats band to `index.html` that summarizes task count, codebase coverage, and language mix. 
- Embed a leaderboard preview section on the landing page (`#leaderboard`) that re-uses the existing leaderboard JavaScript hooks (`#leaderboard-table`, `#leaderboard-filters`) and includes a CTA linking to the full `leaderboard.html`.
- Add CSS rules in `assets/style.css` to style the section header, stat cards, and a constrained leaderboard preview (`.leaderboard-preview .leaderboard-table`) so the new content matches existing typography and theming.
- Keep global styles, font imports, and site structure unchanged to preserve the original look-and-feel.

### Testing
- Started a local HTTP server with `python3 -m http.server 8000` and verified the site served without file errors (server running).
- Ran a Playwright-based automated screenshot using Firefox which successfully rendered the updated landing page and produced `artifacts/landing-leaderboard.png` (screenshot succeeded).
- Attempted the same Playwright run with Chromium which crashed in the test environment (headless Chromium produced a SIGSEGV); this is an environment-specific browser crash and does not affect the HTML/CSS changes themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69823b7b0a7c832d81894810abeb6b3b)